### PR TITLE
update peerdependencies to angular 13

### DIFF
--- a/projects/ngx-cookiebot/package.json
+++ b/projects/ngx-cookiebot/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/halloverden/ngx-cookiebot/tree/main/projects/ngx-cookiebot"
   },
   "peerDependencies": {
-    "@angular/common": "8.2.14 - 12",
-    "@angular/core": "8.2.14 - 12"
+    "@angular/common": "8.2.14 - 13",
+    "@angular/core": "8.2.14 - 13"
   }
 }


### PR DESCRIPTION
Your libs works fine in our angular 13 project, but the install needs to be force now because peer dependencies cannot be resolved.