### PR TITLE
angular 13

### DIFF
--- a/projects/ngx-cookiebot/package.json
+++ b/projects/ngx-cookiebot/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/halloverden/ngx-cookiebot/tree/main/projects/ngx-cookiebot"
   },
   "peerDependencies": {
-    "@angular/common": "8.2.14 - 12",
-    "@angular/core": "8.2.14 - 12"
+    "@angular/common": "8.2.14 - 13",
+    "@angular/core": "8.2.14 - 13"
   }
 }


### PR DESCRIPTION
I have tested the package in an angular 13 application. I installed it without legacy peer dependencies. 

I did not see any issues and the lib worked as expected.

I initially thought there was an rxjs version issue due to incompatible types, but I included the lib in the wrong way (I installed the whole repo instead of just the lib). 