### PR TITLE
fix(onInit): use same logic for cd like for uc script

### DIFF
--- a/projects/ngx-cookiebot/src/lib/ngx-cookiebot.component.ts
+++ b/projects/ngx-cookiebot/src/lib/ngx-cookiebot.component.ts
@@ -34,7 +34,6 @@ export class NgxCookiebotComponent implements OnInit {
       this._ngxCookiebotConfig.cbId +
       '/cd.js';
     script.async = true;
-    script.type = 'module';
     this.ngxCookiebotElement.nativeElement.append(script);
   }
 }

--- a/projects/ngx-cookiebot/src/lib/ngx-cookiebot.component.ts
+++ b/projects/ngx-cookiebot/src/lib/ngx-cookiebot.component.ts
@@ -27,10 +27,12 @@ export class NgxCookiebotComponent implements OnInit {
     const script = document.createElement('script');
     script.type = 'text/javascript';
     script.id = 'CookieDeclaration';
-    const cdn = this._ngxCookiebotConfig.cdn
-      ? this._ngxCookiebotConfig.cdn
-      : 'https://consent.cookiebot.com/';
-    script.src = cdn + this._ngxCookiebotConfig.cbId + '/cd.js';
+    script.src =
+      'https://consent.cookiebot.' +
+      this._ngxCookiebotConfig.cdn +
+      '/' +
+      this._ngxCookiebotConfig.cbId +
+      '/cd.js';
     script.async = true;
     script.type = 'module';
     this.ngxCookiebotElement.nativeElement.append(script);


### PR DESCRIPTION
In the last refactoring you changed the cdn configuration to be either eu or com, but in the component it expects still the complete cdn name. 

I updated this to follow your logic now, also.